### PR TITLE
Use -lconfig++ for libconfig++ instead of find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.2.0)
 project(tuxdump VERSION 0.1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-
-find_package(libconfig++ REQUIRED)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -lconfig++")
 
 if (CMAKE_BUILD_TYPE EQUAL "Debug")
     set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")


### PR DESCRIPTION
This should fix the issue listed below with people installing libconfig++ from Debian repos.
```CMake Error at CMakeLists.txt:6 (find_package):
By not providing "Findlibconfig++.cmake" in CMAKE_MODULE_PATH this project
has asked CMake to find a package configuration file provided by
"libconfig++", but CMake did not find one.

Could not find a package configuration file provided by "libconfig++" with
any of the following names:

    libconfig++Config.cmake
    libconfig++-config.cmake

Add the installation prefix of "libconfig++" to CMAKE_PREFIX_PATH or set
"libconfig++_DIR" to a directory containing one of the above files.  If
"libconfig++" provides a separate development package or SDK, be sure it
has been installed.
```
[Video Example](https://my.mixtape.moe/hxpwll.mp4)
The cmake modules needed to find the headers don't appear to come with libconfig++ in the Debian repos, this should work with any distro not distributing the cmake modules in their respective packages.
